### PR TITLE
Making two step dockerfile separating build from runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
+FROM golang:1.24-bookworm AS build
+WORKDIR /go
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . . 
+RUN go build .
+
+
 FROM gcr.io/distroless/base-debian12@sha256:27769871031f67460f1545a52dfacead6d18a9f197db77110cfc649ca2a91f44
 ENV PORT=8080
-COPY ./db-mcp /bin/db-mcp
+COPY --from=build /go/db-mcp /bin/db-mcp
+COPY ./northwind.db /northwind.db
 ENTRYPOINT ["/bin/db-mcp"]


### PR DESCRIPTION
This is compatible with docker buildx to produce images suitable for multiple platforms 

e.g. docker buildx build  --platform=linux/amd64,linux/amd64/v2,linux/arm64 .
